### PR TITLE
fix(mobile): Android back button navigates back instead of exiting the app

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { View, Text, TouchableOpacity, ScrollView, Image, Modal, StyleSheet, StatusBar, Alert, Keyboard } from 'react-native'
+import { View, Text, TouchableOpacity, ScrollView, Image, Modal, StyleSheet, StatusBar, Alert, Keyboard, BackHandler, Platform } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { WebView } from 'react-native-webview'
 import type { WebViewNavigation } from 'react-native-webview'
@@ -45,6 +45,7 @@ interface Tab {
   driveKey?: string // for backend cleanup on close
   hasDraft?: boolean // drive has unpublished draft changes (ADR-0012)
   draftPreviewing?: boolean // this tab is rendering the merged draft
+  webCanGoBack?: boolean // web tab's WebView has in-page history to step back through
   stack: NavEntry[] // back/forward history
   sp: number // stack pointer
 }
@@ -520,6 +521,7 @@ export default function Browser () {
       setTabs((prev) => {
         const closing = prev.find((tb) => tb.id === id)
         if (closing?.driveKey) backend.close(closing.driveType, closing.driveKey)
+        delete webviews.current[id]
         const next = prev.filter((tb) => tb.id !== id)
         if (next.length === 0) {
           const fresh = blankTab()
@@ -535,14 +537,41 @@ export default function Browser () {
 
   const onWebNav = useCallback(
     (id: string, nav: WebViewNavigation) => {
-      patch(id, { url: nav.url, input: nav.url, title: nav.title || nav.url, loading: nav.loading })
+      patch(id, { url: nav.url, input: nav.url, title: nav.title || nav.url, loading: nav.loading, webCanGoBack: nav.canGoBack })
       if (!nav.loading) persist.recordVisit(nav.url, nav.title || nav.url)
     },
     [patch, persist]
   )
 
+  // Go back in the active tab: inside a web page's own history first (in-page link navigation lives
+  // in the WebView, not the app stack), then across the tab's app-level nav stack (hyper pages,
+  // typed URLs, home). Returns true if it navigated. Shared by the on-screen ‹ button and Android's
+  // hardware back so the two always agree.
+  const goBackActive = useCallback((): boolean => {
+    const tab = tabsRef.current.find((tb) => tb.id === activeIdRef.current)
+    if (!tab) return false
+    if (tab.kind === 'web' && tab.webCanGoBack) {
+      webviews.current[tab.id]?.goBack()
+      return true
+    }
+    if (tab.sp > 0) {
+      step(tab.id, -1)
+      return true
+    }
+    return false
+  }, [step])
+
+  // Android hardware back navigates back instead of exiting the app. Returning false when there's
+  // nowhere to go lets Android background the app as usual. A visible full-screen Modal (AI/Library/…)
+  // handles its own back via onRequestClose, so this handler won't fire while one is open.
+  useEffect(() => {
+    if (Platform.OS !== 'android') return
+    const sub = BackHandler.addEventListener('hardwareBackPress', goBackActive)
+    return () => sub.remove()
+  }, [goBackActive])
+
   // --- render ------------------------------------------------------------
-  const canBack = active.sp > 0
+  const canBack = active.sp > 0 || (active.kind === 'web' && !!active.webCanGoBack)
   const canForward = active.sp < active.stack.length - 1
   const bookmarked = persist.isBookmarked(active.url)
   // Load the active space's drive registry (its drives, incl. ones added on other devices). A
@@ -608,7 +637,7 @@ export default function Browser () {
         driveType={active.driveType}
         canBack={canBack}
         canForward={canForward}
-        onBack={() => step(active.id, -1)}
+        onBack={goBackActive}
         onForward={() => step(active.id, 1)}
         onFocus={onUrlFocus}
         onBlur={onUrlBlur}


### PR DESCRIPTION
## Problem
On Android, the hardware back button exited (backgrounded) the app instead of navigating back through page history. Worse, for in-page link navigation on a web page, even the on-screen ‹ button was disabled — it only tracked the app-level nav stack, not the WebView's own history.

## Fix
- Register a `hardwareBackPress` handler (Android only) that goes back: **WebView history first** (in-page links), then the **tab's app-level nav stack** (hyper pages, typed URLs, home), and only returns `false` — letting Android background the app — when there's nowhere left to go.
- Track each web tab's `webCanGoBack` (from `onNavigationStateChange`) as a reactive Tab field, so the on-screen ‹ button lights up during in-page navigation too.
- Both the hardware back and the on-screen ‹ button now go through one `goBackActive()`, so they always agree.

Full-screen modals (AI panel, Library, etc.) already handle back via their own `onRequestClose`, so this handler doesn't interfere while one is open.

## Verification
- `tsc --noEmit` clean; unit tests pass (pre-commit hook).
- ⚠️ Not verified on a device — needs a check: click links on a web page → back retraces them, then crosses to the previous hyper/home entry, then backgrounds the app; the ‹ button enables during in-page nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)