### PR TITLE
chore(release): 1.2.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.31](https://github.com/knownasilya/nomad/compare/v1.2.30...v1.2.31) (2026-07-10)
+
+
+### Bug Fixes
+
+* **mobile:** Android back button navigates back instead of exiting ([8a6e5fc](https://github.com/knownasilya/nomad/commit/8a6e5fc0a2f4382a985e81af7f141b958cc9e978))
+* **mobile:** lift AI panel input above the Android keyboard ([72c3397](https://github.com/knownasilya/nomad/commit/72c33975a4bfbee778bf41430ddf0c9032b5620a))
+* **mobile:** show drive name + URL in the AI Bridge edit-consent prompt ([d02856a](https://github.com/knownasilya/nomad/commit/d02856a3a5cb9dec6739ad2a24a8564440822753))
+
 ### [1.2.29](https://github.com/knownasilya/nomad/compare/v1.2.28...v1.2.29) (2026-07-10)
 
 ### [1.2.4](https://github.com/knownasilya/nomad/compare/v1.2.3...v1.2.4) (2022-03-25)

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "nomad",
   "productName": "Nomad",
   "description": "A Peer-to-Peer Web Browser.",
-  "version": "1.2.29",
+  "version": "1.2.31",
   "author": "Blue Link Labs <support@beakerbrowser.com>",
   "copyright": "© 2020, Blue Link Labs",
   "main": "main.build.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomad",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "A peer-to-peer/decentralized web browser",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
Release **1.2.31** — cut with `standard-version`, so both `package.json` and `app/package.json` are bumped (this also fixes the `app/package.json` still sitting at 1.2.29 from the earlier hand-bumped 1.2.30), and `CHANGELOG.md` is regenerated.

### Included (since 1.2.29)
- fix(mobile): Android back button navigates back instead of exiting (#17)
- fix(mobile): lift AI panel input above the Android keyboard (#15)
- fix(mobile): show drive name + URL in the AI Bridge edit-consent prompt (#16)
- ci: build & publish Android AAB/APK in the release workflow (#14)

The `v1.2.31` tag is pushed and the release workflow is building desktop (macOS + Linux) + Android (AAB/APK) into a draft release. Merging this PR lands the version bump + changelog on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)