### PR TITLE
fix(drafts): clear preview flag when a Draft is emptied by discard/publish

### DIFF
--- a/app/bg/hyper/drafts.js
+++ b/app/bg/hyper/drafts.js
@@ -213,6 +213,9 @@ export async function publish(baseKey, { paths = null, force = false } = {}) {
   for (const p of publishedPaths) await autobases.deletePath(v, filePath(baseKey, p));
   // TODO(blobs): purge the corresponding bytes from the dedicated draft-blobs core here.
 
+  // Nothing left staged (all published, no conflicts held back) → clear the preview flag so the
+  // urlbar/tab don't stay stuck previewing a Draft that's now empty (same reasoning as discard).
+  if (!(await listDraft(baseKey)).length) setPreview(baseKey, false);
   emitChanged(baseKey);
   return { published: publishedPaths, conflicts: force ? [] : conflicts };
 }
@@ -224,6 +227,10 @@ export async function discard(baseKey, { paths = null } = {}) {
   const rows = (await listDraft(baseKey)).filter((r) => selected(r.path, paths));
   for (const row of rows) await autobases.deletePath(v, filePath(baseKey, row.path));
   // TODO(blobs): purge draft-blobs for these paths.
+  // Once nothing remains staged, drop the preview flag — it's keyed by Drive and survives the discard
+  // on its own, which would otherwise strand the urlbar/tab in "previewing" state for a Draft that no
+  // longer exists (pane.draftPreviewing reads isPreview).
+  if (!(await listDraft(baseKey)).length) setPreview(baseKey, false);
   emitChanged(baseKey);
   return { discarded: rows.map((r) => r.path) };
 }


### PR DESCRIPTION
## Problem
On desktop, if you **preview a draft** and then **discard** it, the URL bar and tab stay stuck in "previewing" state.

## Cause
Draft preview is a per-Drive flag (`drafts.setPreview`, keyed by Drive key). `discard()` (and `publish()`) removed the staged rows but never cleared that flag — so `isPreview()` stayed `true`, and `pane.draftPreviewing` kept reporting the tab as previewing a Draft that no longer exists.

## Fix
In `drafts.discard()` / `drafts.publish()`, once nothing remains staged, clear the preview flag (`setPreview(baseKey, false)`). The pane's `refreshState()` (which discard/publish already trigger) then emits `draftPreviewing: false` + `hasDraft: false`, resetting the urlbar and tab.

Both the browser-chrome path (`bg/ui/tabs/manager.js`) and the url-first / AI-panel path (`bg/web-apis/bg/fs.ts`) route through `drafts.discard`/`publish`, so both are fixed. Partial discard/publish that leaves changes behind keeps the preview on (only clears when the Draft is fully emptied).

## Verification
- `vitest run` — all 89 tests pass, including the `drafts-overlay` golden.
- ⚠️ Recommend a manual check on desktop: preview a draft → discard → confirm the pen-nib toggle and preview styling clear on the urlbar/tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)