### PR TITLE
fix(session): always preserve tabs across soft and hard close

### DIFF
--- a/app/bg/ui/default-state.js
+++ b/app/bg/ui/default-state.js
@@ -1,6 +1,7 @@
 export function defaultBrowsingSessionState() {
   return {
     windows: [defaultWindowState()],
+    closedWindows: [],
     cleanExit: true,
   };
 }

--- a/app/bg/ui/session-watcher.js
+++ b/app/bg/ui/session-watcher.js
@@ -14,6 +14,10 @@ export default class SessionWatcher {
   static get emptySnapshot() {
     return {
       windows: [],
+      // Tabs of recently-closed windows (most-recent first, capped), kept so a soft close never
+      // loses its tabs: restored on dock-reopen, or on next launch if every window was closed
+      // before quitting. Persisted, unlike an in-memory-only stack.
+      closedWindows: [],
       backgroundTabs: [],
       // We set this to false by default and clean this up when the session
       // exits. If we ever open up a snapshot and this isn't cleaned up assume
@@ -25,7 +29,6 @@ export default class SessionWatcher {
   constructor(userDataDir) {
     this.userDataDir = userDataDir;
     this.snapshot = SessionWatcher.emptySnapshot;
-    this.closedWindowStates = [];
     this.recording = true;
     this.watchers = {};
   }
@@ -63,8 +66,9 @@ export default class SessionWatcher {
       if (this.recording) {
         let i = this.snapshot.windows.indexOf(state);
         this.snapshot.windows.splice(i, 1);
+        // Remember the closed window's tabs (persisted + capped) so they can be restored.
+        this.snapshot.closedWindows = [state, ...(this.snapshot.closedWindows || [])].slice(0, 10);
         this.writeSnapshot();
-        this.closedWindowStates.push(state);
       }
       delete this.watchers[winId];
       watcher.removeAllListeners();
@@ -101,7 +105,9 @@ export default class SessionWatcher {
   }
 
   popLastClosedWindow() {
-    return this.closedWindowStates.pop();
+    const state = (this.snapshot.closedWindows || []).shift();
+    if (state) this.writeSnapshot();
+    return state;
   }
 }
 

--- a/app/bg/ui/windows.js
+++ b/app/bg/ui/windows.js
@@ -67,7 +67,6 @@ export async function setup() {
   userDataDir = jetpack.cwd(app.getPath('userData'));
   sessionWatcher = new SessionWatcher(userDataDir);
   var previousSessionState = getPreviousBrowsingSession();
-  var customStartPage = await settingsDb.get('custom_start_page');
   var isTestDriverActive = !!getEnvVar('NOMAD_TEST_DRIVER');
   var isOpenUrlEnvVar = !!getEnvVar('NOMAD_OPEN_URL');
 
@@ -185,19 +184,26 @@ export async function setup() {
     }
   });
 
+  // Always restore the previous session's tabs so they're preserved across both a hard quit and
+  // closing every window before quitting (falls back to the last soft-closed window's tabs). On an
+  // UNCLEAN exit (crash) we still ask first, in case a bad page caused the crash.
+  const prevWindows = (previousSessionState.windows || []).filter(Boolean);
+  const prevClosed = (previousSessionState.closedWindows || []).filter(Boolean);
+  const hasSession = prevWindows.length > 0 || prevClosed.length > 0;
   if (
     !isTestDriverActive &&
     !isOpenUrlEnvVar &&
-    (customStartPage === 'previous' ||
-      (!previousSessionState.cleanExit && userWantsToRestoreSession()))
+    hasSession &&
+    (previousSessionState.cleanExit || userWantsToRestoreSession())
   ) {
-    // restore old window
+    // restore old window(s)
     restoreBrowsingSession(previousSessionState);
   } else {
     let opts = {};
-    if (previousSessionState.windows[0]) {
+    const pos = prevWindows[0] || prevClosed[0];
+    if (pos) {
       // use the last session's window position
-      let { x, y, width, height } = previousSessionState.windows[0];
+      let { x, y, width, height } = pos;
       opts.x = x;
       opts.y = y;
       opts.width = width;
@@ -447,7 +453,9 @@ export function updateAddedWindowSettings(win, settings) {
 
 export function ensureOneWindowExists() {
   if (numActiveWindows === 0) {
-    createShellWindow();
+    // Reopening after every window was closed (e.g. clicking the macOS dock icon): bring back the
+    // last closed window's tabs rather than a blank window, so a soft close never loses them.
+    createShellWindow(sessionWatcher?.popLastClosedWindow());
   }
 }
 
@@ -528,7 +536,11 @@ function userWantsToRestoreSession() {
 }
 
 function restoreBrowsingSession(previousSessionState) {
-  let { windows } = previousSessionState;
+  let windows = (previousSessionState.windows || []).filter(Boolean);
+  if (!windows.length) {
+    // Every window was soft-closed before the app quit — restore the most recent one's tabs.
+    windows = (previousSessionState.closedWindows || []).slice(0, 1);
+  }
   if (windows.length) {
     for (let windowState of windows) {
       if (windowState) {


### PR DESCRIPTION
## Problem
On desktop, closing the window **without quitting the app** (macOS) loses your tabs — reopening from the dock gives a blank window. Tabs should be preserved always, on both a soft close and a hard close.

## Cause
- **Soft close:** on window close the session watcher spliced the window out of the snapshot and kept it only in an *in-memory* `closedWindowStates` stack. `ensureOneWindowExists()` (dock reopen) then created a blank window, and the in-memory stack is lost on quit.
- **Hard close:** startup only restored the session when `custom_start_page === 'previous'`, but the default is `'blank'` — so a clean quit dropped tabs unless you'd changed that setting. (`custom_start_page` was used *only* to gate this restore.)

## Fix
- **Persist** recently-closed windows' tabs in the session snapshot (`closedWindows`, capped at 10), so soft-closed tabs survive a later quit as well as a dock reopen.
- `ensureOneWindowExists()` restores the **last closed window** instead of a blank one.
- Startup **always restores** the previous session on a clean exit — open windows, falling back to the most recent soft-closed window if every window was closed before quitting. An **unclean** exit (crash) still prompts first. Removed the `custom_start_page` gate.

Restoring a window with no saved pages still yields one default tab (`initializeWindowFromSnapshot` → `create`), so first-run and empty windows are unaffected.

### Scenarios covered
| Action | Before | After |
|---|---|---|
| Close window, reopen via dock (macOS) | blank window | tabs restored |
| Quit with window open, relaunch | blank (default setting) | tabs restored |
| Close all windows, then quit, relaunch | blank | last window's tabs restored |
| Crash | prompt to restore | prompt to restore (unchanged) |

## Verification
- `oxlint` clean on the changed files; `vitest run` — all 89 tests pass.
- ⚠️ Recommend a manual pass on desktop across the four scenarios above (this touches window/session lifecycle, which has no unit coverage).

## Note
This makes session restore unconditional (on clean exit), superseding the `custom_start_page: 'previous'` opt-in — intentional per the "preserve always" requirement. If you want an escape hatch (a setting to start blank), say so and I'll gate it behind a new explicit preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)